### PR TITLE
refactor-gettowngroups

### DIFF
--- a/Common/fn_initCommonConstants.sqf
+++ b/Common/fn_initCommonConstants.sqf
@@ -389,8 +389,11 @@ switch(side player) do {
 	if (isNil 'WF_C_STRUCTURES_MAX_TENTS') then {WF_C_STRUCTURES_MAX_TENTS = 3;};
 
 //--- Apply a towns unit coeficient.
-	WF_C_TOWNS_UNITS_COEF = switch (WF_C_TOWNS_OCCUPATION) do {case 0: {0}; case 1: {1}; case 2: {1.5}; case 3: {2}; case 4: {2.5}; default {1}};
-	WF_C_TOWNS_UNITS_DEFENDER_COEF = switch (WF_C_TOWNS_DEFENDER) do {case 0: {0}; case 1: {1}; case 2: {1.5}; case 3: {2}; case 4: {2.5}; default {1}};
+	if (isNil 'WF_C_TOWNS_OCCUPATION_COEF') then {WF_C_TOWNS_OCCUPATION_COEF = 1;};
+    if (isNil 'WF_C_TOWNS_DEFENDER_COEF') then {WF_C_TOWNS_DEFENDER_COEF = 2;};
+    //--Towns infantry groups types. Index 0 and 1 are reserved (mandatory squads)!--
+    WF_TOWNS_TEAMS = ["Team_AT_", "Team_AA_", "Team_", "Team_MG_", "Team_Sniper_", "Squad_", "Squad_Advanced_"];
+    
 	WF_C_TOWNS_ALL_SIDES = [west, east, resistance, sideEnemy];
 
     //----


### PR DESCRIPTION
Переписал кривую логику выборки пехотных групп для города.
Если надо, забирай.
В идеале нужно весь механизм рефакторить, но там дальше идет логика работы с волнами, я пока в неё не вникал.